### PR TITLE
Update twofa.entitlements

### DIFF
--- a/Supporting/twofa.entitlements
+++ b/Supporting/twofa.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-        <key>com.apple.application-identifier</key>
-	<string>N2JEMR5FZG.org.janiskirsteins.twofa</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>N2JEMR5FZG</string>
 	<key>com.apple.application-identifier</key>


### PR DESCRIPTION
Remove duplicate `com.apple.application-identifier` to attempt fixing #4, specifically —

> Failed to parse entitlements: AMFIUnserializeXML: duplicate dictionary key near line 10